### PR TITLE
Remove sub navigation background

### DIFF
--- a/pubs/styles/base.scss
+++ b/pubs/styles/base.scss
@@ -90,3 +90,7 @@ body, .govuk-template__body {
   display: inline-block;
   min-height: 24px;
 }
+
+.x-govuk-sub-navigation__section-item {
+  background: none;
+}


### PR DESCRIPTION
## Purpose of pull request
Removes background on the sub navigation items so it does not overlay the body background colour

## How to test
Create a sub navigation, without this PR the items have a white background which overlays the body grey background. With this PR the sub navigation does not have a background.